### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -1,0 +1,18 @@
+# Issue Templates - Quick Guide
+## 5 Simple Templates
+- `feature.md` - New features
+- `bug.md` - Bug fixes
+- `refactor.md` - Code improvements
+- `docs.md` - Documentation
+- `tests.md` - Test coverage
+## Usage
+**GitHub Web:** New Issue → Pick template → Fill it → Submit
+**CLI:**
+```bash
+gh issue create --template feature.md
+```
+**Quick (no template):**
+```bash
+gh issue create --title "feat: thing" --body "Note"
+```
+Done! 🚀

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,21 @@
+---
+name: Bug
+about: Something's broken
+title: 'fix: '
+labels: bug
+assignees: pablosalgado
+---
+## Problem
+What's broken.
+## Steps to Reproduce
+1. Do this
+2. See error
+## Expected vs Actual
+**Expected:** What should happen  
+**Actual:** What actually happens
+## Error Message
+```
+Paste error here if any
+```
+## Fix Ideas
+Any ideas on how to fix it.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 README
+    url: https://github.com/pablosalgado/budget-buddy/blob/main/README.md
+    about: Project documentation
+  - name: 📋 Guidelines
+    url: https://github.com/pablosalgado/budget-buddy/tree/main/.github/instructions
+    about: Coding standards

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -5,7 +5,7 @@ title: 'docs: '
 labels: documentation
 assignees: pablosalgado
 ---
-## What Docs
+## Documentation Needed
 What needs documenting.
 ## Why
 Why this documentation is needed.

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,16 @@
+---
+name: Docs
+about: Add or update documentation
+title: 'docs: '
+labels: documentation
+assignees: pablosalgado
+---
+## What Docs
+What needs documenting.
+## Why
+Why this documentation is needed.
+## Tasks
+- [ ] Write/update docs
+- [ ] Review for clarity
+## Files
+List files that need documentation updates.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,18 @@
+---
+name: Feature
+about: Add a new feature
+title: 'feat: '
+labels: enhancement
+assignees: pablosalgado
+---
+## What
+What you're building in 1-2 sentences.
+## Why
+Why you need this.
+## Tasks
+- [ ] Main task 1
+- [ ] Main task 2
+- [ ] Write tests
+- [ ] Update docs if needed
+## Notes
+Any extra context or links.

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,17 @@
+---
+name: Refactor
+about: Improve existing code
+title: 'refactor: '
+labels: refactor
+assignees: pablosalgado
+---
+## What to Refactor
+What code needs improvement.
+## Why
+Why it needs refactoring (performance, readability, etc.).
+## Tasks
+- [ ] Refactor X
+- [ ] Ensure tests still pass
+- [ ] Check performance if relevant
+## Notes
+Any additional context.

--- a/.github/ISSUE_TEMPLATE/tests.md
+++ b/.github/ISSUE_TEMPLATE/tests.md
@@ -1,0 +1,18 @@
+---
+name: Tests
+about: Add or improve tests
+title: 'test: '
+labels: testing
+assignees: pablosalgado
+---
+## What Needs Tests
+What code is missing tests.
+## Current Coverage
+Current: X% → Target: 85%+
+## Tasks
+- [ ] Add tests for X
+- [ ] Add tests for Y
+- [ ] Cover edge cases
+## Files
+- `app/models/example.rb`
+- `app/controllers/example_controller.rb`


### PR DESCRIPTION
Add 5 simple issue templates to standardize issue creation and improve project organization following conventional commit format.
- Add feature.md template for new features
- Add bug.md template for bug reports
- Add refactor.md template for code improvements
- Add docs.md template for documentation
- Add tests.md template for test coverage
- Add config.yml for template chooser settings
- Add README.md with quick usage guide Templates are simple and practical for solo learning projects, requiring minimal time to fill out (~30 seconds per issue). Closes #8